### PR TITLE
Fix: Permanent failing jobs should be removed from the queue

### DIFF
--- a/buildjob/buildjob.go
+++ b/buildjob/buildjob.go
@@ -1,0 +1,38 @@
+package buildjob
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+// BuildJob represents a job for the gobuilder to build including the
+// repository and a number of tries already made to build it
+type BuildJob struct {
+	Repository         string
+	NumberOfExecutions int
+}
+
+// ToByte creats a gob encoded version of the BuildJob to store in text
+// queues or other locations
+func (b *BuildJob) ToByte() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(b)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// FromBytes reads a []byte representation created by ToBytes and
+// returns a reference to the BuildJob object for further usage
+func FromBytes(b []byte) (*BuildJob, error) {
+	buf := bytes.NewBuffer(b)
+	dec := gob.NewDecoder(buf)
+	var tmp BuildJob
+	err := dec.Decode(&tmp)
+	if err != nil {
+		return nil, err
+	}
+	return &tmp, nil
+}

--- a/webhooks.go
+++ b/webhooks.go
@@ -11,6 +11,7 @@ import (
 
 	"launchpad.net/goamz/s3"
 
+	"github.com/Luzifer/gobuilder/buildjob"
 	"github.com/flosch/pongo2"
 	"github.com/kr/beanstalk"
 	"github.com/segmentio/go-loggly"
@@ -93,8 +94,19 @@ func sendToQueue(repository string) error {
 		Conn: conn,
 		Name: "gobuild.luzifer.io",
 	}
-	// Put the job into the queue and give it a time to run of 300 secs
-	_, err = t.Put([]byte(repository), 1, 0, 300*time.Second)
+
+	job := buildjob.BuildJob{
+		Repository:         repository,
+		NumberOfExecutions: 0,
+	}
+	queueEntry, err := job.ToByte()
+	if err != nil {
+		log.Error(fmt.Sprintf("%q", err))
+		return err
+	}
+
+	// Put the job into the queue and give it a time to run of 900 secs
+	_, err = t.Put([]byte(queueEntry), 1, 0, 900*time.Second)
 	if err != nil {
 		log.Error(fmt.Sprintf("%q", err))
 		return err


### PR DESCRIPTION
Currently the queue just gets filled up when there is a job which is constantly failing because of it is not buildable in some way. To prevent the queue to filling with unbildable jobs just remove them after 5 tries and set the status to `failing`.
