### PR TITLE
Fix: Don't show duplicates in last build list

### DIFF
--- a/cmd/starter/main.go
+++ b/cmd/starter/main.go
@@ -144,8 +144,9 @@ func fetchBuildJob() {
 
 	if buildOK {
 		orFail(redisClient.Set(fmt.Sprintf("project::%s::build-status", repo), "finished", 0, 0, false, false))
-		redisClient.LPush("last-builds", repo)
-		redisClient.LTrim("last-builds", 0, 10)
+		redisClient.ZAdd("last-builds", map[string]float64{
+			repo: float64(time.Now().Unix()),
+		})
 		_ = os.RemoveAll(tmpDir)
 
 		log.WithFields(logrus.Fields{

--- a/static.go
+++ b/static.go
@@ -16,7 +16,7 @@ func handleFrontPage(res http.ResponseWriter) {
 	activeWorkers, _ := redisClient.ZCount("active-workers", timestamp, "+inf")
 
 	queueLength, _ := redisClient.LLen("build-queue")
-	lastBuilds, _ := redisClient.LRange("last-builds", 0, 10)
+	lastBuilds, _ := redisClient.ZRevRange("last-builds", 0, 10, false)
 
 	template := pongo2.Must(pongo2.FromFile("frontend/newbuild.html"))
 	template.ExecuteWriter(pongo2.Context{


### PR DESCRIPTION
Using a Redis list causes duplicates in the list when a repo is built twice. The ordered set removed that flaw without implementing own duplicate check or sorting logic. A score (timestamp) is overwritten and the set reordered.

@jbenet PTAL
