### PR TITLE
add in config setting to disable go fmt runs

### DIFF
--- a/build-image/builder.sh
+++ b/build-image/builder.sh
@@ -42,8 +42,6 @@ if [ -f Godeps/Godeps.json ]; then
   godep restore
 fi
 
-go fmt ./...
-
 mkdir -p /tmp/go-build
 wget -qO /tmp/go-build/.build_commit "https://gobuilder.me/api/v1/${gopath}/already-built?commit=${short_commit}" || touch /tmp/go-build/.build_commit
 wget -qO /tmp/go-build/.build.db https://gobuilder.me/api/v1/${gopath}/build.db || bash -c 'echo "{}" > /tmp/go-build/.build.db'
@@ -55,6 +53,11 @@ fi
 # Upload .gobuilder.yml to enable notifications even when script fails while build
 cp .gobuilder.yml /artifacts/
 sync
+
+if [ "$(configreader read no_go_fmt)" != "true" ]
+then
+	go fmt ./...
+fi
 
 if ! ( test "${FORCE_BUILD}" == "true" ); then
   if [ "$(cat /tmp/go-build/.build_commit)" == "${short_commit}" ]; then

--- a/buildconfig/structs.go
+++ b/buildconfig/structs.go
@@ -16,6 +16,7 @@ type BuildConfig struct {
 	VersionFile string                       `yaml:"version_file,omitempty"`
 	Notify      notifier.NotifyConfiguration `yaml:"notify,omitempty"`
 	BuildMatrix map[string]ArchConfig        `yaml:"build_matrix,omitempty"`
+	NoGoFmt     string                       `yaml:"no_go_fmt,omitempty"`
 }
 
 type buildConfigV0 struct {

--- a/cmd/configreader/main.go
+++ b/cmd/configreader/main.go
@@ -103,6 +103,8 @@ func handleCommand(context *cli.Context, filter func(string)) {
 		filter(getBuildTags(cfg))
 	case "ld_flags":
 		filter(getLDFlags(cfg))
+	case "no_go_fmt":
+		filter(cfg.NoGoFmt)
 	}
 }
 


### PR DESCRIPTION
This will allow users to opt out of having go fmt run on their code before being built. Useful in cases where build constraints are used to prevent building under certain conditions as `go fmt` ignores the build constraints.

I'm not certain how gobuilder is tested, so I havent actually tried this out yet.
